### PR TITLE
Add AccInt provider

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -353,6 +353,13 @@ PROVIDERS = {
         "raw_base": "https://raw.githubusercontent.com/EmblemCompany/Agent-skills/main",
         "skills_path_prefix": "skills/",
     },
+    "accint": {
+        "name": "AccInt",
+        "repo": "https://github.com/maxbaluev/accreted-intelligence",
+        "api_tree_url": "https://api.github.com/repos/maxbaluev/accreted-intelligence/git/trees/main?recursive=1",
+        "raw_base": "https://raw.githubusercontent.com/maxbaluev/accreted-intelligence/main",
+        "skills_path_prefix": "plugins/claude/skills/",
+    },
 }
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")


### PR DESCRIPTION
## Summary
- Add AccInt as a provider for the Agent Skills Directory.
- Point the aggregator at `maxbaluev/accreted-intelligence` and the public Claude skills under `plugins/claude/skills/`.
- The provider currently exposes three valid skills: `commitments`, `frames`, and `solve`.

## Validation
- `python -m py_compile scripts/aggregate.py scripts/test_provider.py`
- `pytest -q`
- `git diff --check`
- `GITHUB_TOKEN=... python scripts/test_provider.py <accint-provider-config>`
  - tree API accessible, 84 items
  - found 3 `SKILL.md` files
  - parsed all 3 successfully
